### PR TITLE
SM7325Pkg Update

### DIFF
--- a/Silicon/Qualcomm/SM7325Pkg/Drivers/SmBiosTableDxe/DataDefinitions.h
+++ b/Silicon/Qualcomm/SM7325Pkg/Drivers/SmBiosTableDxe/DataDefinitions.h
@@ -284,8 +284,16 @@ SMBIOS_TABLE_TYPE4 mProcessorInfoType4_a78_Prime = {
     0  // ProcessorVoltageIndicateLegacy
   },
   0,                     // ExternalClock
+#if SOC_TYPE == 1
+  2520,                  // MaxSpeed
+  2520,                  // CurrentSpeed
+#elif SOC_TYPE == 2
+  2710,                  // MaxSpeed
+  2710,                  // CurrentSpeed
+#else
   2400,                  // MaxSpeed
   2400,                  // CurrentSpeed
+#endif
   0x41,                  // Status
   ProcessorUpgradeOther, // ProcessorUpgrade
   0,                     // L1CacheHandle

--- a/Silicon/Qualcomm/SM7325Pkg/SM7325Pkg.dsc.inc
+++ b/Silicon/Qualcomm/SM7325Pkg/SM7325Pkg.dsc.inc
@@ -23,7 +23,7 @@
   PLATFORM_HAS_PSCI_MEMPROTECT_FAILING_ERRATA         = 0
 
 [BuildOptions]
-  *_*_AARCH64_CC_FLAGS = -march=armv8-a+crypto+rcpc
+  *_*_AARCH64_CC_FLAGS = -march=armv8.2-a+crypto+rcpc
 
 [PcdsFixedAtBuild]
   # Timer
@@ -46,10 +46,10 @@
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosProcessorModel|"Snapdragon (TM) 778G @ 2.40 GHz"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosProcessorRetailModel|"SM7325"
 !elseif $(SOC_TYPE) == 1
-  gSiliciumPkgTokenSpaceGuid.PcdSmbiosProcessorModel|"Snapdragon (TM) 778G+ @ 2.50 GHz"
+  gSiliciumPkgTokenSpaceGuid.PcdSmbiosProcessorModel|"Snapdragon (TM) 778G Plus @ 2.52 GHz"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosProcessorRetailModel|"SM7325-AE"
 !elseif $(SOC_TYPE) == 2
-  gSiliciumPkgTokenSpaceGuid.PcdSmbiosProcessorModel|"Snapdragon (TM) 782G @ 2.70 GHz"
+  gSiliciumPkgTokenSpaceGuid.PcdSmbiosProcessorModel|"Snapdragon (TM) 782G @ 2.71 GHz"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosProcessorRetailModel|"SM7325-AF"
 !endif
 


### PR DESCRIPTION

1. SM7325,SM7325-AE,SM7325-AF core speeds are different, so added
2. Snapdragon 778g uses ARMv8.2-A
3. Name and speed modified